### PR TITLE
#14 use specific git revision for used tf modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Terraform module to provision a Docker Swarm mode cluster in a single availabili
 
 ## Requirements
 
-- Terraform >= 0.10.6
+- Terraform >= 0.11.2
 - Digitalocean account / API token with write access
 - SSH Keys added to your DigitalOcean account
 - [jq](https://github.com/stedolan/jq)
@@ -20,7 +20,8 @@ Terraform module to provision a Docker Swarm mode cluster in a single availabili
 
 ```hcl
 module "swarm-cluster" {
-  source           = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode"
+  source           = "thojkooi/docker-swarm-mode/digitalocean"
+  version          = "0.1.0"
   domain           = "do.example.com"
   total_managers   = 3
   total_workers    = 2
@@ -48,7 +49,8 @@ You can use user_data to manually install Docker on other OS images or use it to
 
 ```hcl
 module "swarm-cluster" {
-    source            = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode"
+    source            = "thojkooi/docker-swarm-mode/digitalocean"
+    version           = "0.1.0"
     total_managers    = 1
     total_workers     = 1
     domain            = "do.example.com"
@@ -71,7 +73,8 @@ module "swarm-cluster" {
 ```hcl
 
 module "swarm-cluster" {
-    source           = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode"
+    source           = "thojkooi/docker-swarm-mode/digitalocean"
+    version          = "0.1.0"
     total_managers   = 1
     total_workers    = 0
     region           = "ams3"
@@ -85,7 +88,7 @@ resource "digitalocean_droplet" "worker" {
     ssh_keys           = "${var.ssh_keys}"
     image              = "coreos-alpha"
     region             = "ams3"
-    size               = "512mb"
+    size               = "s-1vcpu-1gb"
     private_networking = true
     backups            = false
     ipv6               = false

--- a/examples/extra-droplets/main.tf
+++ b/examples/extra-droplets/main.tf
@@ -9,7 +9,8 @@ variable "ssh_keys" {
 }
 
 module "swarm-cluster" {
-  source           = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode"
+  source           = "thojkooi/docker-swarm-mode/digitalocean"
+  version          = "0.1.0"
   total_managers   = 1
   total_workers    = 0
   region           = "ams3"

--- a/examples/firewall/main.tf
+++ b/examples/firewall/main.tf
@@ -21,7 +21,8 @@ resource "digitalocean_tag" "worker" {
 }
 
 module "swarm-cluster" {
-  source           = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode"
+  source           = "thojkooi/docker-swarm-mode/digitalocean"
+  version          = "0.1.0"
   total_managers   = 3
   total_workers    = 5
   region           = "ams3"

--- a/examples/user-data/main.tf
+++ b/examples/user-data/main.tf
@@ -21,7 +21,11 @@ resource "digitalocean_tag" "worker" {
 }
 
 module "swarm-cluster" {
-  source            = "../../"
+  source = "../../"
+
+  # source            = "thojkooi/docker-swarm-mode/digitalocean"
+  # version           = "0.1.0"
+
   total_managers    = 1
   total_workers     = 1
   domain            = "do.example.com"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "managers" {
-  source   = "github.com/thojkooi/terraform-digitalocean-swarm-managers"
+  source   = "github.com/thojkooi/terraform-digitalocean-swarm-managers?ref=v0.1.1"
   do_token = "${var.do_token}"
 
   image  = "${var.manager_image}"
@@ -18,7 +18,7 @@ module "managers" {
 }
 
 module "workers" {
-  source   = "github.com/thojkooi/terraform-digitalocean-swarm-workers"
+  source   = "github.com/thojkooi/terraform-digitalocean-swarm-workers?ref=v0.1.0"
   do_token = "${var.do_token}"
 
   image  = "${var.worker_image}"


### PR DESCRIPTION
- Update README to reflect using terraform module registry
- Update requirements for terraform version to 0.11.2. Previous version 0.10.6 should still work with this, but module examples may not due to module version attribute introduced in terraform 0.11.0.
- Set managers module to v0.1.1
- Set workers module to v0.1.0
