### PR TITLE
#11 change droplet default size to s-1vcpu-1gb

### DIFF
--- a/examples/extra-droplets/main.tf
+++ b/examples/extra-droplets/main.tf
@@ -24,7 +24,7 @@ resource "digitalocean_droplet" "worker" {
   ssh_keys           = "${var.ssh_keys}"
   image              = "coreos-alpha"
   region             = "ams3"
-  size               = "512mb"
+  size               = "s-1vcpu-1gb"
   private_networking = true
   backups            = false
   ipv6               = false

--- a/examples/firewall/main.tf
+++ b/examples/firewall/main.tf
@@ -22,13 +22,15 @@ resource "digitalocean_tag" "worker" {
 
 module "swarm-cluster" {
   source           = "thojkooi/docker-swarm-mode/digitalocean"
-  version          = "0.1.0"
   total_managers   = 3
   total_workers    = 5
+  version          = "0.1.1"
   region           = "ams3"
   do_token         = "${var.do_token}"
   manager_ssh_keys = "${var.ssh_keys}"
   worker_ssh_keys  = "${var.ssh_keys}"
+  manager_size     = "s-1vcpu-1gb"
+  worker_size      = "s-1vcpu-1gb"
   manager_tags     = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.manager.id}"]
   worker_tags      = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.worker.id}"]
   domain           = "do.example.com"

--- a/variables.tf
+++ b/variables.tf
@@ -53,12 +53,12 @@ variable "worker_image" {
 
 variable "manager_size" {
   description = "Droplet size of worker nodes"
-  default     = "512mb"
+  default     = "s-1vcpu-1gb"
 }
 
 variable "worker_size" {
   description = "Droplet size of worker nodes"
-  default     = "512mb"
+  default     = "s-1vcpu-1gb"
 }
 
 variable "manager_name" {


### PR DESCRIPTION
Change the default droplet size values to the new DO droplet plans.

See: https://blog.digitalocean.com/new-droplet-plans/

Note: this change will restart droplets when applied. Set `manager_size` and `worker_size` to previous values if you want to keep the old default size (`521mb`) to avoid the restart.

Closes #11