### PR TITLE
Move manager and worker nodes into the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 *.tfstate
 *.tfstate.*
 .terraform
+
+# Ignore secret files
+.secrets

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Terraform module to provision a Docker Swarm mode cluster in a single availabili
 - SSH Keys added to your DigitalOcean account
 - [jq](https://github.com/stedolan/jq)
 
-
 ## Usage
 
 ```hcl
@@ -64,8 +63,6 @@ module "swarm_mode_cluster" {
 ```
 
 > Note that for this to work, you need to open the Docker remote API port in both iptables (not necessary with default images) and the DigitalOcean cloud firewall.
-
-
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -11,114 +11,119 @@ Terraform module to provision a Docker Swarm mode cluster in a single availabili
 
 ## Requirements
 
-- Terraform >= 0.11.2
+- Terraform >= 0.11.7
 - Digitalocean account / API token with write access
 - SSH Keys added to your DigitalOcean account
 - [jq](https://github.com/stedolan/jq)
+
 
 ## Usage
 
 ```hcl
 module "swarm-cluster" {
   source           = "thojkooi/docker-swarm-mode/digitalocean"
-  version          = "0.1.0"
+  version          = "1.0.0"
   domain           = "do.example.com"
   total_managers   = 3
   total_workers    = 2
-  do_token         = "${var.do_token}"
   manager_ssh_keys = [1234, 1235, ...]
   worker_ssh_keys  = [1234, 1235, ...]
+
+  providers {}
 }
 ```
 
 ### SSH Key
 
-Terraform uses an SSH key to connect to the created droplets in order to issue `docker swarm join` commands. By default this uses `~/.ssh/id_rsa`. If you wish to use a different key, you can modify this using the variable `provision_ssh_key`. You also need to ensure the public key is added to your DigitalOcean account and it's ID is listed in both the `manager_ssh_keys` and `worker_ssh_keys` lists.
+Terraform uses an SSH key to connect to the created droplets in order to issue `docker swarm join` commands. By default this uses `~/.ssh/id_rsa`. If you wish to use a different key, you can modify this using the variable `provision_ssh_key`. You also need to ensure the public key is added to your DigitalOcean account and it's listed in both the `manager_ssh_keys` and `worker_ssh_keys` lists.
 
-### Notes
+### Exposing the Docker API
 
-This module does not set up a firewall or modifies any other security settings. Please configure this by providing user data for the manager and worker nodes. Also set up firewall rules on DigitalOcean for the cluster, to ensure only cluster members can access the internal Swarm ports. You can use the [digitalocean-docker-swarm-firewall](https://github.com/thojkooi/terraform-digitalocean-docker-swarm-firewall) module for this. Look in the [firewall examples directory](https://github.com/thojkooi/terraform-digitalocean-docker-swarm-mode/tree/master/examples/firewall) for inspiration on how to do this.
+You can expose the Docker API to interact with the cluster remotely. This is done by providing a certificate and private key. See the [Docker TLS example](/examples/remote-api-tls/certs) for information on how to create these.
+
+```hcl
+module "swarm_mode_cluster" {
+  source           = "thojkooi/docker-swarm-mode/digitalocean"
+  version          = "1.0.0"
+  domain           = "do.example.com"
+  total_managers   = 3
+  total_workers    = 2
+  manager_ssh_keys = [1234, 1235, ...]
+  worker_ssh_keys  = [1234, 1235, ...]
+
+  remote_api_ca          = "${path.module}/certs/ca.pem"
+  remote_api_certificate = "${path.module}/certs/server.pem"
+  remote_api_key         = "${path.module}/certs/server-key.pem"
+
+  manager_size = "s-2vcpu-4gb"
+  worker_size  = "s-1vcpu-1gb"
+  manager_tags = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.manager.id}"]
+  worker_tags  = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.worker.id}"]
+  providers = {}
+}
+```
+
+> Note that for this to work, you need to open the Docker remote API port in both iptables (not necessary with default images) and the DigitalOcean cloud firewall.
+
+
+
+## Notes
+
+### Installing Docker
+
+It module does not install Docker - this is left up to the user of this module. The default image used comes with Docker CE pre-installed. It's encouraged to provide your own image or use configuration management tooling to install Docker.
+
+You can also install Docker using user data. See the [user-data example](#).
+
+This module has been tested with Docker CE v18.06 and later. Earlier versions should work (v1.13 and up), but have not been tested.
+
+### Supported OS
+
+This module has been tested with CoreOS, and CentOS 7.4 provided by DigitalOcean, but it should work with other distributions as well, as long as `Docker` and `sudo` packages are installed.
+
+### Ports & Firewall
+
+Ensure the following ports are open on the firewall;
+
+Port       | Description                       | Note
+---------- | --------------------------------- | -------
+`2377/TCP` | cluster management communications | Cluster
+`7946/TCP` | Container network discovery       | Cluster
+`7946/UDP` | Container network discovery       | Cluster
+`4789/UDP` | Container overlay network         | Cluster
+`2376/TCP` | Docker Remote API | Optionally, when exposing the Docker Remote API
+
+For example, when using the Docker images provided by DigitalOcean, run the following command:
+
+```bash
+ufw allow 2377
+ufw allow 7946
+ufw allow 7946/udp
+ufw allow 4789/udp
+```
+
+#### Cloud Firewall
+
+Also set up firewall rules on DigitalOcean for the cluster, to ensure only cluster members can access the internal Swarm ports. You can use the [digitalocean-docker-swarm-firewall](https://github.com/thojkooi/terraform-digitalocean-docker-swarm-firewall) module for this. Look in the [firewall examples directory](https://github.com/thojkooi/terraform-digitalocean-docker-swarm-mode/tree/master/examples/firewall) for inspiration on how to do this.
 
 ## Examples
 
 For examples, see the [examples directory](https://github.com/thojkooi/terraform-digitalocean-docker-swarm-mode/tree/master/examples).
 
-### Using user data
-
-You can use user_data to manually install Docker on other OS images or use it to install configuration management tooling such as Puppet.
-
-```hcl
-module "swarm-cluster" {
-    source            = "thojkooi/docker-swarm-mode/digitalocean"
-    version           = "0.1.0"
-    total_managers    = 1
-    total_workers     = 1
-    domain            = "do.example.com"
-    do_token          = "${var.do_token}"
-    manager_ssh_keys  = "${var.ssh_keys}"
-    worker_ssh_keys   = "${var.ssh_keys}"
-    manager_image     = "centos-7-x64"
-    worker_image      = "centos-7-x64"
-    provision_user    = "root"
-    manager_user_data = "${file("scripts/install-docker-ce.sh")}"
-    worker_user_data  = "${file("scripts/install-docker-ce.sh")}"
-    manager_tags      = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.manager.id}"]
-    worker_tags       = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.worker.id}"]
-}
-
-```
-
-### Extra nodes
-
-```hcl
-
-module "swarm-cluster" {
-    source           = "thojkooi/docker-swarm-mode/digitalocean"
-    version          = "0.1.0"
-    total_managers   = 1
-    total_workers    = 0
-    region           = "ams3"
-    do_token         = "${var.do_token}"
-    manager_ssh_keys = "${var.ssh_keys}"
-    worker_ssh_keys  = "${var.ssh_keys}"
-    domain           = "do.example.com"
-}
-
-resource "digitalocean_droplet" "worker" {
-    ssh_keys           = "${var.ssh_keys}"
-    image              = "coreos-alpha"
-    region             = "ams3"
-    size               = "s-1vcpu-1gb"
-    private_networking = true
-    backups            = false
-    ipv6               = false
-    name               = "custom-node"
-    depends_on         = ["module.swarm-cluster"]
-
-    connection {
-        type        = "ssh"
-        user        = "core"
-        private_key = "${file("~/.ssh/id_rsa")}"
-        timeout     = "2m"
-    }
-
-    provisioner "remote-exec" {
-        inline = [
-            "sudo docker swarm join --token ${module.swarm-cluster.worker_token} ${module.swarm-cluster.manager_ips_private[0]}:2377"
-        ]
-    }
-
-}
-```
-
-## Swarm set-up
+## Swarm mode set-up
 
 ### Manager nodes
 
-First a single Swarm mode manager is provisioned. This is the leader node. If you have additional manager nodes, these will be provisioned after this step. Once the manager nodes have been provisioned, Terraform will initialize the Swarm on the first manager node and retrieve the join tokens. It will then have all the managers join the cluster.
+First a single Swarm mode manager is provisioned. This is the initial leader node. If you have additional manager nodes, these will be provisioned after this step. Once the manager nodes have been provisioned, Terraform will initialize the Swarm on the first manager node and retrieve the join tokens. It will then have all the managers join the cluster.
 
-If the cluster is already up and running, Terraform will check with the first leader node to refresh the join tokens. It will join any additional manager nodes that are provisioned automagically to the Swarm.
+If the cluster is already up and running, Terraform will check with the first leader node to refresh the join tokens. It will join any additional manager nodes that are provisioned to the Swarm mode cluster.
 
-#### Worker nodes
+#### Access the API
 
-Worker nodes should be used to run the Docker Swarm mode Services. By default, 2 worker nodes are provisioned. Set the number of desired worker nodes using the following variable: `total_workers`
+To expose the Swarm mode API in HA, create a load balancer and forward tcp traffic to port `2376`. Ensure you expose the docker remote API using certificates when doing this. Alternatively you can do DNS round-robin load balancing.
+
+When you do not wish to expose your Docker API, you can use SSH to connect to one of the manager nodes and access the Docker API through this.
+
+### Worker nodes
+
+Worker nodes should be used to run the Docker Swarm mode Services. By default, 2 worker nodes are provisioned. Set the number of desired worker nodes using the following variable: `total_workers`.

--- a/examples/extra-droplets/main.tf
+++ b/examples/extra-droplets/main.tf
@@ -14,7 +14,6 @@ module "swarm-cluster" {
   total_managers   = 1
   total_workers    = 0
   region           = "ams3"
-  do_token         = "${var.do_token}"
   manager_ssh_keys = "${var.ssh_keys}"
   worker_ssh_keys  = "${var.ssh_keys}"
   domain           = "do.example.com"

--- a/examples/firewall/main.tf
+++ b/examples/firewall/main.tf
@@ -26,7 +26,6 @@ module "swarm-cluster" {
   total_workers    = 5
   version          = "0.1.1"
   region           = "ams3"
-  do_token         = "${var.do_token}"
   manager_ssh_keys = "${var.ssh_keys}"
   worker_ssh_keys  = "${var.ssh_keys}"
   manager_size     = "s-1vcpu-1gb"

--- a/examples/usage/README.md
+++ b/examples/usage/README.md
@@ -1,0 +1,18 @@
+# Usage example
+
+This example shows how to create the cluster, exposing the Docker remote API and configure some basic firewall rules.
+
+## Requirements
+
+- Certificates & keys to configure TLS. See certs/README.md on how to create those using cfssl.
+- DigitalOcean API token
+
+## Running it
+
+You can try out this example by providing a digitalocean access token and running `terraform apply`. Note that you may need to run `terraform init` first.
+
+This will create:
+
+- a cluster with multiple managers and workers
+- a load balancer to access the remote API
+- cluster internal firewall rules

--- a/examples/usage/certs/.gitignore
+++ b/examples/usage/certs/.gitignore
@@ -1,0 +1,4 @@
+*.json
+*.pem
+*.csr
+.docker

--- a/examples/usage/certs/README.md
+++ b/examples/usage/certs/README.md
@@ -1,0 +1,55 @@
+# Generate certificates
+
+How to create certificates to configure the Docker Remote API using TLS.
+
+References:
+- https://coreos.com/os/docs/latest/generate-self-signed-certificates.html
+- https://docs.docker.com/engine/security/https/#create-a-ca-server-and-client-keys-with-openssl
+
+## Using cfssl
+
+This is following the [CoreOS self signed certificates](https://coreos.com/os/docs/latest/generate-self-signed-certificates.html) docs.
+
+### Installing
+
+https://github.com/cloudflare/cfssl#installation
+
+### Creating certificates
+
+```bash
+./create_certificates.sh example.com
+```
+
+> **Please keep ca-key.pem file in safe**. This key allows to create any kind of certificates within your CA.
+
+You can create as many client certificates as you want, just repeat the proces.
+
+### Prepare docker client access
+
+Create the client certificates:
+```bash
+# Create certificate with CN=client
+./create_client_cert.sh client
+
+# Create certificate with CN=admin
+./create_client_cert.sh admin
+```
+
+When you generated the client certificates, you need a copy of the `ca.pem`, the `client.pem` and `client-key.pem` files to authenticate with the Docker API. To do so, move those files to your `~/.docker` directory. Alternatively, use a different directory and configure `DOCKER_CERT_PATH`.
+
+```bash
+mkdir ~/.docker
+cp ca.pem ~/.docker/ca.pem
+mv client.pem ~/.docker/cert.pem
+mv client-key.pem ~/.docker/key.pem
+```
+
+```bash
+export DOCKER_CERT_PATH=~/.docker
+```
+
+Alternatively, run `install-client-bundle.sh` to configure the API access:
+
+```bash
+source install-client-bundle.sh example.com
+```

--- a/examples/usage/certs/create_certificates.sh
+++ b/examples/usage/certs/create_certificates.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+echo '{"CN":"CA","key":{"algo":"rsa","size":4096}}' | cfssl gencert -initca - | cfssljson -bare ca -
+echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json
+export ADDRESS=$1
+export NAME=server
+echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":4096}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME

--- a/examples/usage/certs/create_client_cert.sh
+++ b/examples/usage/certs/create_client_cert.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export ADDRESS=
+export NAME=$1
+echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":4096}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME

--- a/examples/usage/certs/install-client-bundle.sh
+++ b/examples/usage/certs/install-client-bundle.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo Using for remote API host name: $1
+
+echo Installing client bundle...
+mkdir .docker
+cp ca.pem .docker/ca.pem
+cp client.pem .docker/cert.pem
+cp client-key.pem .docker/key.pem
+
+echo Configuring Docker client to talk to remote API...
+export DOCKER_CERT_PATH=$(pwd)/.docker
+export DOCKER_HOST=tcp://$1:2376 DOCKER_TLS_VERIFY=1

--- a/examples/usage/main.tf
+++ b/examples/usage/main.tf
@@ -1,0 +1,112 @@
+variable "do_token" {}
+
+variable "ssh_keys" {
+  type = "list"
+}
+
+provider "digitalocean" {
+  token = "${var.do_token}"
+}
+
+resource "digitalocean_tag" "cluster" {
+  name = "swarm-mode-cluster"
+}
+
+resource "digitalocean_tag" "manager" {
+  name = "manager"
+}
+
+resource "digitalocean_tag" "worker" {
+  name = "worker"
+}
+
+module "swarm_mode_cluster" {
+  source = "../../"
+
+  total_managers = 3
+  total_workers  = 1
+  region         = "ams3"
+  domain         = "swarm.containerinfra.com"
+
+  manager_ssh_keys = "${var.ssh_keys}"
+  worker_ssh_keys  = "${var.ssh_keys}"
+
+  remote_api_ca          = "${path.module}/certs/ca.pem"
+  remote_api_certificate = "${path.module}/certs/server.pem"
+  remote_api_key         = "${path.module}/certs/server-key.pem"
+
+  manager_size = "s-2vcpu-4gb"
+  worker_size  = "s-1vcpu-1gb"
+  manager_tags = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.manager.id}"]
+  worker_tags  = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.worker.id}"]
+  providers    = {}
+}
+
+# Load balancer
+resource "digitalocean_loadbalancer" "manager_api_access" {
+  name   = "docker-swarm-api.ams3.prd.containerinfra.com"
+  region = "ams3"
+
+  forwarding_rule {
+    entry_port     = 2376
+    entry_protocol = "tcp"
+
+    target_port     = 2376
+    target_protocol = "tcp"
+  }
+
+  healthcheck {
+    port     = 22
+    protocol = "tcp"
+
+    check_interval_seconds   = 5
+    response_timeout_seconds = 3
+    unhealthy_threshold      = 5
+    healthy_threshold        = 3
+  }
+
+  droplet_tag = "${digitalocean_tag.manager.id}"
+}
+
+# Firewall rules
+module "basic-fw-rules" {
+  source  = "thojkooi/firewall-rules/digitalocean"
+  version = "1.0.0"
+
+  prefix = "do-example-com"
+  tags   = ["${digitalocean_tag.cluster.id}"]
+}
+
+module "api-access-firewall" {
+  source                        = "github.com/thojkooi/terraform-digitalocean-firewall-docker-api?ref=v0.1.2"
+  prefix                        = "do-example-com"
+  tags                          = ["${digitalocean_tag.manager.id}"]
+  api_access_from_adresses      = []
+  api_access_load_balancer_uids = ["${digitalocean_loadbalancer.manager_api_access.id}"]
+}
+
+module "swarm-mode-firewall" {
+  source  = "thojkooi/docker-swarm-firewall/digitalocean"
+  version = "1.0.0"
+
+  prefix              = "do-example-com"
+  cluster_droplet_ids = []
+  cluster_tags        = ["${digitalocean_tag.cluster.id}"]
+}
+
+resource "digitalocean_firewall" "http" {
+  name = "do-example-com-http-access-fw"
+  tags = ["${digitalocean_tag.cluster.id}"]
+
+  inbound_rule = [
+    {
+      protocol         = "tcp"
+      port_range       = "80"
+      source_addresses = ["0.0.0.0/0", "::/0"]
+    },
+  ]
+}
+
+output "manager_api_access" {
+  value = "${digitalocean_loadbalancer.manager_api_access.ip}"
+}

--- a/examples/usage/scripts/install-docker-ce.sh
+++ b/examples/usage/scripts/install-docker-ce.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Install requirements for Docker
+yum -y update
+yum install -y yum-utils device-mapper-persistent-data lvm2
+
+# Add docker-ce repository and enable docker-ce-edge
+yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+yum-config-manager --enable docker-ce-edge
+yum -y makecache fast
+
+# Install and enable docker
+yum -y install docker-ce
+
+sleep 1;
+
+systemctl enable docker
+systemctl start docker

--- a/examples/user-data/main.tf
+++ b/examples/user-data/main.tf
@@ -29,7 +29,6 @@ module "swarm-cluster" {
   total_managers    = 1
   total_workers     = 1
   domain            = "do.example.com"
-  do_token          = "${var.do_token}"
   manager_ssh_keys  = "${var.ssh_keys}"
   worker_ssh_keys   = "${var.ssh_keys}"
   manager_image     = "centos-7-x64"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 module "managers" {
-  source   = "github.com/thojkooi/terraform-digitalocean-swarm-managers?ref=v0.1.2"
-  do_token = "${var.do_token}"
+  source = "github.com/thojkooi/terraform-digitalocean-swarm-managers?ref=v0.2.0"
 
   image  = "${var.manager_image}"
   size   = "${var.manager_size}"
@@ -12,14 +11,17 @@ module "managers" {
   user_data       = "${var.manager_user_data}"
   tags            = "${var.manager_tags}"
 
+  remote_api_ca          = "${var.remote_api_ca}"
+  remote_api_key         = "${var.remote_api_key}"
+  remote_api_certificate = "${var.remote_api_certificate}"
+
   ssh_keys          = "${var.worker_ssh_keys}"
   provision_ssh_key = "${var.provision_ssh_key}"
   provision_user    = "${var.provision_user}"
 }
 
 module "workers" {
-  source   = "github.com/thojkooi/terraform-digitalocean-swarm-workers?ref=v0.2.0"
-  do_token = "${var.do_token}"
+  source = "github.com/thojkooi/terraform-digitalocean-swarm-workers?ref=v0.3.0"
 
   image  = "${var.worker_image}"
   size   = "${var.worker_size}"
@@ -31,7 +33,6 @@ module "workers" {
   user_data       = "${var.worker_user_data}"
   tags            = "${var.worker_tags}"
 
-  manager_public_ip  = "${element(module.managers.ipv4_addresses, 0)}"
   manager_private_ip = "${element(module.managers.ipv4_addresses_private, 0)}"
   join_token         = "${module.managers.worker_token}"
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "managers" {
-  source = "github.com/thojkooi/terraform-digitalocean-swarm-managers?ref=v0.2.0"
+  source = "./modules/managers"
 
   image  = "${var.manager_image}"
   size   = "${var.manager_size}"
@@ -21,7 +21,7 @@ module "managers" {
 }
 
 module "workers" {
-  source = "github.com/thojkooi/terraform-digitalocean-swarm-workers?ref=v0.3.0"
+  source = "./modules/workers"
 
   image  = "${var.worker_image}"
   size   = "${var.worker_size}"

--- a/modules/managers/LICENSE
+++ b/modules/managers/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Thomas Kooi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/modules/managers/README.md
+++ b/modules/managers/README.md
@@ -1,0 +1,68 @@
+# Terraform - DigitalOcean Docker Swarm mode managers
+
+Terraform module to provision and bootstrap a Docker Swarm mode cluster with multiple managers using a private network on DigitalOcean.
+
+- [Requirements](#requirements)
+- [Usage](#usage)
+- [Examples](#examples)
+
+## Requirements
+
+- Terraform >= 0.11.7
+- Digitalocean account / API token with write access
+- SSH Keys added to your DigitalOcean account
+- [jq](https://github.com/stedolan/jq)
+
+## Usage
+
+```hcl
+module "swarm-cluster" {
+  source          = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode//modules/managers"
+  domain          = "do.example.com"
+  total_instances = 3
+  ssh_keys        = [1234, 1235, ...]
+  providers {}
+}
+```
+
+### SSH Key
+
+Terraform uses an SSH key to connect to the created droplets in order to issue `docker swarm join` commands. By default this uses `~/.ssh/id_rsa`. If you wish to use a different key, you can modify this using the variable `provision_ssh_key`. You also need to ensure the public key is added to your DigitalOcean account and it's ID is listed in the `ssh_keys` list.
+
+### Exposing the Docker API
+
+You can expose the Docker API to interact with the cluster remotely. This is done by providing a certificate and private key. See the [Docker TLS example](https://github.com/thojkooi/terraform-digitalocean-docker-swarm-mode/tree/master/modules/managers/tree/master/examples/remote-api-tls).
+
+```hcl
+module "swarm_mode_cluster" {
+  source          = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode//modules/managers"
+
+  domain          = "do.example.com"
+  total_instances = 3
+  ssh_keys        = [1234, 1235, ...]
+
+  remote_api_ca          = "${path.module}/certs/ca.pem"
+  remote_api_certificate  = "${path.module}/certs/server.pem"
+  remote_api_key         = "${path.module}/certs/server-key.pem"
+
+  size = "s-2vcpu-4gb"
+
+  tags = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.manager.id}"]
+
+  providers = {}
+}
+```
+
+### Notes
+
+This module does not set up a firewall or modifies any other security settings. Please configure this by providing user data for the manager nodes. Also set up firewall rules on DigitalOcean for the cluster, to ensure only cluster members can access the internal Swarm ports.
+
+## Examples
+
+For examples, see the [examples directory](https://github.com/thojkooi/terraform-digitalocean-docker-swarm-mode/tree/master/modules/managers/tree/master/examples).
+
+## Swarm set-up
+
+First a single Swarm mode manager is provisioned. This is the leader node. If you have additional manager nodes, these will be provisioned after this step. Once the manager nodes have been provisioned, Terraform will initialize the Swarm on the first manager node and retrieve the join tokens. It will then have all the managers join the cluster.
+
+If the cluster is already up and running, Terraform will check with the first leader node to refresh the join tokens. It will join any additional manager nodes that are provisioned automagically to the Swarm.

--- a/modules/managers/circle.yml
+++ b/modules/managers/circle.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: jonatanblue/gitlab-ci-terraform:latest
+    steps:
+      - checkout
+      - run:
+          name: Validate terraform code
+          command: |
+            terraform init
+            terraform validate -check-variables=false

--- a/modules/managers/examples/add-workers/README.md
+++ b/modules/managers/examples/add-workers/README.md
@@ -1,0 +1,11 @@
+# Example: extra droplets
+
+This example shows how to add other droplets that are not provisioned by this module to the Swarm cluster using output values.
+
+## Running it
+
+You can try out this example by providing a digitalocean access token and running `terraform apply`. Note that you may need to run `terraform init` first.
+
+## Destroying it
+
+Note when destroying, first remove all worker nodes (`count = 0`) before running `terraform destroy`.

--- a/modules/managers/examples/add-workers/main.tf
+++ b/modules/managers/examples/add-workers/main.tf
@@ -1,0 +1,31 @@
+variable "do_token" {}
+
+provider "digitalocean" {
+  token = "${var.do_token}"
+}
+
+variable "ssh_keys" {
+  type = "list"
+}
+
+module "swarm-cluster-managers" {
+  source          = "../../"
+  total_instances = 1
+  region          = "ams3"
+  ssh_keys        = "${var.ssh_keys}"
+  domain          = "do.example.com"
+}
+
+module "workers" {
+  source = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode/tree/master/modules/workers"
+
+  size            = "s-1vcpu-1gb"
+  name            = "web"
+  region          = "ams3"
+  domain          = "do.example.com"
+  total_instances = 1
+  ssh_keys        = "${var.ssh_keys}"
+
+  manager_private_ip = "${element(module.swarm-cluster-managers.ipv4_addresses_private, 0)}"
+  join_token         = "${module.swarm-cluster-managers.worker_token}"
+}

--- a/modules/managers/examples/remote-api-tls/README.md
+++ b/modules/managers/examples/remote-api-tls/README.md
@@ -1,0 +1,57 @@
+# Remote API TLS
+
+Create managers and expose the Docker Remote API over TLS.
+
+For this, you need to create certificates and keys.
+
+### Creating CA and server certificates
+
+This is an example using cfssl, following the [CoreOS self signed certificates](https://coreos.com/os/docs/latest/generate-self-signed-certificates.html) docs.
+
+More references can be found:
+
+- https://coreos.com/os/docs/latest/generate-self-signed-certificates.html
+- https://docs.docker.com/engine/security/https/#create-a-ca-server-and-client-keys-with-openssl
+
+
+```bash
+echo '{"CN":"CA","key":{"algo":"rsa","size":4096}}' | cfssl gencert -initca - | cfssljson -bare ca -
+echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json
+export ADDRESS=example.com
+export NAME=server
+echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":4096}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+```
+
+Upgrade the `ADDRESS` variable to match the host name / address used to access the Docker API.
+
+### Create the client certificates
+
+```bash
+export ADDRESS=
+export NAME=client
+echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":4096}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+```
+
+### Create the managers
+
+```
+$ terraform apply
+
+data.template_file.provision_manager: Refreshing state...
+data.template_file.provision_first_manager: Refreshing state...
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+ <= read (data resources)
+....
+Plan: 18 to add, 0 to change, 0 to destroy.
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value:
+```
+
+You can use the client certificates to access the docker api.

--- a/modules/managers/examples/remote-api-tls/main.tf
+++ b/modules/managers/examples/remote-api-tls/main.tf
@@ -1,0 +1,55 @@
+variable "do_token" {}
+
+variable "ssh_keys" {
+  type = "list"
+}
+
+provider "digitalocean" {
+  token = "${var.do_token}"
+}
+
+resource "digitalocean_tag" "manager" {
+  name = "swarm-mode-manager"
+}
+
+module "managers" {
+  source = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode//modules/managers"
+
+  domain          = "do.example.com"
+  total_instances = 3
+  ssh_keys        = ["${var.ssh_keys}"]
+
+  remote_api_ca          = "${path.module}/ca.pem"
+  remote_api_certificate = "${path.module}/server.pem"
+  remote_api_key         = "${path.module}/server-key.pem"
+
+  size = "s-2vcpu-4gb"
+
+  tags = ["${digitalocean_tag.manager.id}"]
+
+  providers = {}
+}
+
+module "basic-fw-rules" {
+  source  = "thojkooi/firewall-rules/digitalocean"
+  version = "1.0.0"
+
+  prefix = "do-example-com"
+  tags   = ["${digitalocean_tag.manager.id}"]
+}
+
+module "api-access-firewall" {
+  source                   = "github.com/thojkooi/terraform-digitalocean-firewall-docker-api?ref=v0.1.2"
+  prefix                   = "do-example-com"
+  tags                     = ["${digitalocean_tag.manager.id}"]
+  api_access_from_adresses = ["0.0.0.0/0", "::/0"]
+}
+
+module "swarm-mode-firewall" {
+  source  = "thojkooi/docker-swarm-firewall/digitalocean"
+  version = "1.0.0"
+
+  prefix              = "do-example-com"
+  cluster_droplet_ids = []
+  cluster_tags        = ["${digitalocean_tag.manager.id}"]
+}

--- a/modules/managers/examples/user-data/README.md
+++ b/modules/managers/examples/user-data/README.md
@@ -1,0 +1,9 @@
+# Example: user data
+
+This example uses the Centos 7 image from DigitalOcean and uses user data to install Docker.
+
+## Running it
+
+You can try out this example by providing a digitalocean access token and running `terraform apply`. Note that you may need to run `terraform init` first.
+
+This example takes a while to complete, since Terraform is waiting until Docker is available on the provisioned droplets. This may take roughly 4 minutes.

--- a/modules/managers/examples/user-data/main.tf
+++ b/modules/managers/examples/user-data/main.tf
@@ -1,0 +1,28 @@
+variable "do_token" {}
+
+variable "ssh_keys" {
+  type = "list"
+}
+
+provider "digitalocean" {
+  token = "${var.do_token}"
+}
+
+resource "digitalocean_tag" "cluster" {
+  name = "cluster"
+}
+
+resource "digitalocean_tag" "manager" {
+  name = "manager"
+}
+
+module "swarm-cluster-managers" {
+  source          = "../../"
+  total_instances = 1
+  domain          = "do.example.com"
+  ssh_keys        = "${var.ssh_keys}"
+  image           = "centos-7-x64"
+  provision_user  = "root"
+  user_data       = "${file("scripts/install-docker-ce.sh")}"
+  tags            = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.manager.id}"]
+}

--- a/modules/managers/examples/user-data/scripts/install-docker-ce.sh
+++ b/modules/managers/examples/user-data/scripts/install-docker-ce.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Install requirements for Docker
+yum -y update
+yum install -y yum-utils device-mapper-persistent-data lvm2
+
+# Add docker-ce repository and enable docker-edge
+yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+yum-config-manager --enable docker-ce-edge
+yum -y makecache fast
+
+# Install and enable docker
+yum -y install docker-ce
+
+sleep 1;
+
+systemctl enable docker
+systemctl start docker

--- a/modules/managers/main.tf
+++ b/modules/managers/main.tf
@@ -1,0 +1,151 @@
+data "template_file" "provision_first_manager" {
+  template = "${file("${path.module}/scripts/provision-first-manager.sh")}"
+
+  vars {
+    docker_cmd   = "${var.docker_cmd}"
+    availability = "${var.availability}"
+  }
+}
+
+data "template_file" "provision_manager" {
+  template = "${file("${path.module}/scripts/provision-manager.sh")}"
+
+  vars {
+    docker_cmd   = "${var.docker_cmd}"
+    availability = "${var.availability}"
+  }
+}
+
+resource "digitalocean_droplet" "manager" {
+  ssh_keys           = "${var.ssh_keys}"
+  image              = "${var.image}"
+  region             = "${var.region}"
+  size               = "${var.size}"
+  private_networking = true
+  backups            = "${var.backups}"
+  ipv6               = false
+  tags               = ["${var.tags}"]
+  user_data          = "${var.user_data}"
+  count              = "${var.total_instances}"
+  name               = "${format("%s-%02d.%s.%s", var.name, count.index + 1, var.region, var.domain)}"
+
+  connection {
+    type        = "ssh"
+    user        = "${var.provision_user}"
+    private_key = "${file("${var.provision_ssh_key}")}"
+    timeout     = "2m"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.provision_first_manager.rendered}"
+    destination = "/tmp/provision-first-manager.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/provision-first-manager.sh",
+      "if [ ${count.index} -eq 0 ]; then /tmp/provision-first-manager.sh ${self.ipv4_address_private}; fi",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    when = "destroy"
+
+    inline = [
+      "timeout 25 docker swarm leave",
+    ]
+
+    on_failure = "continue"
+  }
+}
+
+# Optionally expose Docker API using certificates
+resource "null_resource" "manager_api_access" {
+  count = "${var.remote_api_key == "" || var.remote_api_certificate == "" || var.remote_api_ca == "" ? 0 : var.total_instances}"
+
+  triggers {
+    cluster_instance_ids = "${join(",", digitalocean_droplet.manager.*.id)}"
+    certificate          = "${md5(file("${var.remote_api_certificate}"))}"
+  }
+
+  connection {
+    host        = "${element(digitalocean_droplet.manager.*.ipv4_address, count.index)}"
+    type        = "ssh"
+    user        = "${var.provision_user}"
+    private_key = "${file("${var.provision_ssh_key}")}"
+    timeout     = "2m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p ~/.docker",
+    ]
+  }
+
+  provisioner "file" {
+    source      = "${var.remote_api_ca}"
+    destination = "~/.docker/ca.pem"
+  }
+
+  provisioner "file" {
+    source      = "${var.remote_api_certificate}"
+    destination = "~/.docker/server-cert.pem"
+  }
+
+  provisioner "file" {
+    source      = "${var.remote_api_key}"
+    destination = "~/.docker/server-key.pem"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/scripts/certs/default.sh"
+    destination = "~/.docker/install_certificates.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x ~/.docker/install_certificates.sh",
+      "~/.docker/install_certificates.sh",
+    ]
+  }
+}
+
+data "external" "swarm_tokens" {
+  program    = ["bash", "${path.module}/scripts/get-swarm-join-tokens.sh"]
+  depends_on = ["null_resource.manager_api_access"]
+
+  query = {
+    host        = "${element(digitalocean_droplet.manager.*.ipv4_address, 0)}"
+    user        = "${var.provision_user}"
+    private_key = "${var.provision_ssh_key}"
+  }
+}
+
+resource "null_resource" "bootstrap" {
+  count      = "${var.total_instances}"
+  depends_on = ["null_resource.manager_api_access"]
+
+  triggers {
+    cluster_instance_ids = "${join(",", digitalocean_droplet.manager.*.id)}"
+  }
+
+  connection {
+    host        = "${element(digitalocean_droplet.manager.*.ipv4_address, count.index)}"
+    type        = "ssh"
+    user        = "${var.provision_user}"
+    private_key = "${file("${var.provision_ssh_key}")}"
+    timeout     = "2m"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.provision_manager.rendered}"
+    destination = "/tmp/provision-manager.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/provision-manager.sh",
+      "/tmp/provision-manager.sh ${digitalocean_droplet.manager.0.ipv4_address_private} ${lookup(data.external.swarm_tokens.result, "manager")}",
+    ]
+  }
+}

--- a/modules/managers/outputs.tf
+++ b/modules/managers/outputs.tf
@@ -1,0 +1,21 @@
+output "ipv4_addresses" {
+  value       = ["${digitalocean_droplet.manager.*.ipv4_address}"]
+  description = "The manager nodes public ipv4 adresses"
+}
+
+output "ipv4_addresses_private" {
+  value       = ["${digitalocean_droplet.manager.*.ipv4_address_private}"]
+  description = "The manager nodes private ipv4 adresses"
+}
+
+output "manager_token" {
+  value       = "${lookup(data.external.swarm_tokens.result, "manager", "")}"
+  description = "The Docker Swarm manager join token"
+  sensitive   = true
+}
+
+output "worker_token" {
+  value       = "${lookup(data.external.swarm_tokens.result, "worker", "")}"
+  description = "The Docker Swarm worker join token"
+  sensitive   = true
+}

--- a/modules/managers/scripts/certs/coreos.sh
+++ b/modules/managers/scripts/certs/coreos.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Install certificates for the Docker Remote API
+# Based on:
+# - https://coreos.com/os/docs/latest/customizing-docker.html
+# - https://docs.docker.com/engine/reference/commandline/dockerd/
+# -https://docs.docker.com/engine/security/https/#secure-by-default
+
+sudo systemctl stop docker
+sudo systemctl disable docker
+
+sudo mkdir -p /var/ssl
+sudo mv ~/.docker/{server-cert.pem,server-key.pem,ca.pem} /var/ssl/
+
+sudo cat<<-EOF > /etc/systemd/system/docker-tls-tcp.socket
+[Unit]
+Description=Docker Secured Socket for the API
+
+[Socket]
+ListenStream=2376
+BindIPv6Only=both
+Service=docker.service
+
+[Install]
+WantedBy=sockets.target
+EOF
+
+sudo systemctl enable docker-tls-tcp.socket
+sudo systemctl stop docker
+sudo systemctl start docker-tls-tcp.socket
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo cat<<-EOF > /etc/systemd/system/docker.service.d/10-tls-verify.conf
+[Service]
+Environment="DOCKER_OPTS=--tlsverify=true --tlscacert=/var/ssl/ca.pem --tlscert=/var/ssl/server-cert.pem --tlskey=/var/ssl/server-key.pem"
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker.service

--- a/modules/managers/scripts/certs/default.sh
+++ b/modules/managers/scripts/certs/default.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+sudo mkdir -p /var/ssl
+sudo mv ~/.docker/{server-cert.pem,server-key.pem,ca.pem} /var/ssl/
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo bash -c 'cat<<-EOF > /etc/systemd/system/docker.service.d/10-tls-verify.conf
+[Service]
+Environment="DOCKER_OPTS=--tlsverify=true --tlscacert=/var/ssl/ca.pem --tlscert=/var/ssl/server-cert.pem --tlskey=/var/ssl/server-key.pem"
+ExecStart=
+ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix://var/run/docker.sock --tlsverify=true --tlscacert=/var/ssl/ca.pem --tlscert=/var/ssl/server-cert.pem --tlskey=/var/ssl/server-key.pem
+EOF'
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker

--- a/modules/managers/scripts/get-swarm-join-tokens.sh
+++ b/modules/managers/scripts/get-swarm-join-tokens.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Processing JSON in shell scripts
+# https://www.terraform.io/docs/providers/external/data_source.html#processing-json-in-shell-scripts
+# Credits to https://github.com/knpwrs/docker-swarm-terraform for inspiration on how to do this
+
+eval "$(jq -r '@sh "HOST=\(.host) USER=\(.user) PRIVATE_KEY=\(.private_key)"')"
+
+# Fetch the manager join token
+MANAGER=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PRIVATE_KEY \
+    $USER@$HOST timeout 5 docker swarm join-token manager -q)
+
+# Fetch the worker join token
+WORKER=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PRIVATE_KEY \
+    $USER@$HOST timeout 5 docker swarm join-token worker -q)
+
+# Produce a JSON object containing the tokens
+jq -n --arg manager "${MANAGER}" --arg worker "$WORKER" \
+    '{"manager":$manager,"worker":$worker}'

--- a/modules/managers/scripts/provision-first-manager.sh
+++ b/modules/managers/scripts/provision-first-manager.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+MANAGER_PRIVATE_ADDR=$1
+
+# Wait until Docker is running correctly
+while [ -z "$(${docker_cmd} info | grep CPUs)" ]; do
+  echo Waiting for Docker to start...
+  sleep 2
+done
+
+${docker_cmd} swarm init --advertise-addr $MANAGER_PRIVATE_ADDR

--- a/modules/managers/scripts/provision-manager.sh
+++ b/modules/managers/scripts/provision-manager.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+MANAGER_PRIVATE_ADDR=$1
+JOIN_TOKEN=$2
+
+# Wait until Docker is running correctly
+while [ -z "$(${docker_cmd} info | grep CPUs)" ]; do
+  echo Waiting for Docker to start...
+  sleep 2
+done
+
+# Check if we are not already joined into a Swarm
+if [ -z "$(${docker_cmd} info | grep 'Swarm: active')" ]; then
+  # Join cluster
+  ${docker_cmd} swarm join --token $JOIN_TOKEN $MANAGER_PRIVATE_ADDR:2377;
+fi

--- a/modules/managers/variables.tf
+++ b/modules/managers/variables.tf
@@ -1,0 +1,81 @@
+variable "domain" {
+  description = "Domain name used in droplet hostnames, e.g example.com"
+}
+
+variable "ssh_keys" {
+  type        = "list"
+  description = "A list of SSH IDs or fingerprints to enable in the format [12345, 123456] that are added to manager nodes"
+}
+
+variable "provision_ssh_key" {
+  default     = "~/.ssh/id_rsa"
+  description = "File path to SSH private key used to access the provisioned nodes. Ensure this key is listed in the manager and work ssh keys list"
+}
+
+variable "provision_user" {
+  default     = "core"
+  description = "User used to log in to the droplets via ssh for issueing Docker commands"
+}
+
+variable "region" {
+  description = "Datacenter region in which the cluster will be created"
+  default     = "ams3"
+}
+
+variable "total_instances" {
+  description = "Total number of managers in cluster"
+  default     = 1
+}
+
+variable "image" {
+  description = "Droplet image used for the manager nodes"
+  default     = "coreos-alpha"
+}
+
+variable "size" {
+  description = "Droplet size of manager nodes"
+  default     = "s-1vcpu-1gb"
+}
+
+variable "name" {
+  description = "Prefix for name of manager nodes"
+  default     = "manager"
+}
+
+variable "backups" {
+  description = "Enable DigitalOcean droplet backups"
+  default     = false
+}
+
+variable "user_data" {
+  description = "User data content for manager nodes"
+  default     = ""
+}
+
+variable "docker_cmd" {
+  description = "Docker command"
+  default     = "sudo docker"
+}
+
+variable "tags" {
+  description = "List of DigitalOcean tag ids"
+  default     = []
+  type        = "list"
+}
+
+variable "availability" {
+  description = "Availability of the node ('active'|'pause'|'drain')"
+  default     = "active"
+}
+
+variable "remote_api_ca" {
+  default = ""
+}
+
+variable "remote_api_key" {
+  default = ""
+}
+
+variable "remote_api_certificate" {
+  default = ""
+}

--- a/modules/workers/LICENSE
+++ b/modules/workers/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Thomas Kooi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/modules/workers/README.md
+++ b/modules/workers/README.md
@@ -1,0 +1,41 @@
+# Terraform - DigitalOcean Docker Swarm mode workers
+
+Terraform module to provision a Docker Swarm mode worker nodes to join a cluster using a private network on DigitalOcean.
+
+[![CircleCI](https://circleci.com/gh/thojkooi/terraform-digitalocean-swarm-workers.svg?style=svg)](https://circleci.com/gh/thojkooi/terraform-digitalocean-swarm-workers)
+
+- [Requirements](#requirements)
+- [Usage](#usage)
+
+## Requirements
+
+- Terraform >= 0.11.7
+- Digitalocean account / API token with write access
+- SSH Keys added to your DigitalOcean account
+
+## Usage
+
+```hcl
+
+module "workers" {
+  source   = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode/tree/master/modules/workers"
+
+  size            = "s-1vcpu-1gb"
+  name            = "web"
+  region          = "ams3"
+  domain          = "example.com"
+  total_instances = 3
+
+  manager_private_ip = "${element(digitalocean_droplet.manager.*.ipv4_address_private, 0)}"
+  join_token         = "${lookup(data.external.swarm_tokens.result, "worker")}"
+
+  ssh_keys          = [1234, 1235, ...]
+  provision_ssh_key = "~/.ssh/id_rsa"
+  provision_user    = "core"
+}
+
+```
+
+### SSH Key
+
+Terraform uses an SSH key to connect to the created droplets in order to issue `docker swarm join` commands. By default this uses `~/.ssh/id_rsa`. If you wish to use a different key, you can modify this using the variable `provision_ssh_key`. You also need to ensure the public key is added to your DigitalOcean account and it's ID is listed in the `ssh_keys` list.

--- a/modules/workers/circle.yml
+++ b/modules/workers/circle.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: jonatanblue/gitlab-ci-terraform:latest
+    steps:
+      - checkout
+      - run:
+          name: Validate terraform code
+          command: |
+            terraform init
+            terraform validate -check-variables=false

--- a/modules/workers/main.tf
+++ b/modules/workers/main.tf
@@ -1,0 +1,52 @@
+data "template_file" "join_cluster_as_worker" {
+  template = "${file("${path.module}/scripts/join.sh")}"
+
+  vars {
+    docker_cmd         = "${var.docker_cmd}"
+    availability       = "${var.availability}"
+    manager_private_ip = "${var.manager_private_ip}"
+  }
+}
+
+resource "digitalocean_droplet" "node" {
+  ssh_keys           = "${var.ssh_keys}"
+  image              = "${var.image}"
+  region             = "${var.region}"
+  size               = "${var.size}"
+  private_networking = true
+  backups            = "${var.backups}"
+  ipv6               = false
+  user_data          = "${var.user_data}"
+  tags               = ["${var.tags}"]
+  count              = "${var.total_instances}"
+  name               = "${format("%s-%02d.%s.%s", var.name, count.index + 1, var.region, var.domain)}"
+
+  connection {
+    type        = "ssh"
+    user        = "${var.provision_user}"
+    private_key = "${file("${var.provision_ssh_key}")}"
+    timeout     = "2m"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.join_cluster_as_worker.rendered}"
+    destination = "/tmp/join_cluster_as_worker.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/join_cluster_as_worker.sh",
+      "/tmp/join_cluster_as_worker.sh ${var.join_token}",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    when = "destroy"
+
+    inline = [
+      "docker swarm leave",
+    ]
+
+    on_failure = "continue"
+  }
+}

--- a/modules/workers/outputs.tf
+++ b/modules/workers/outputs.tf
@@ -1,0 +1,19 @@
+output "ipv4_addresses" {
+  value       = ["${digitalocean_droplet.node.*.ipv4_address}"]
+  description = "The nodes public ipv4 adresses"
+}
+
+output "ipv4_addresses_private" {
+  value       = ["${digitalocean_droplet.node.*.ipv4_address_private}"]
+  description = "The nodes private ipv4 adresses"
+}
+
+output "droplet_ids" {
+  value       = ["${digitalocean_droplet.node.*.id}"]
+  description = "The droplet ids"
+}
+
+output "droplet_hostnames" {
+  value       = ["${digitalocean_droplet.node.*.name}"]
+  description = "The droplet names"
+}

--- a/modules/workers/scripts/join.sh
+++ b/modules/workers/scripts/join.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Wait until Docker is running correctly
+while [ -z "$(${docker_cmd} info | grep CPUs)" ]; do
+  echo Waiting for Docker to start...
+  sleep 2
+done
+
+# Join cluster
+${docker_cmd} swarm join --token $1 \
+  --availability ${availability} ${manager_private_ip}:2377

--- a/modules/workers/variables.tf
+++ b/modules/workers/variables.tf
@@ -1,0 +1,77 @@
+variable "domain" {
+  description = "Domain name used in droplet hostnames, e.g example.com"
+}
+
+variable "join_token" {
+  description = "Join token for the nodes"
+}
+
+variable "manager_private_ip" {
+  description = "Private ip adress of a manager node, used to have a node join the existing cluster"
+}
+
+variable "ssh_keys" {
+  type        = "list"
+  description = "A list of SSH IDs or fingerprints to enable in the format [12345, 123456] that are added to worker nodes"
+}
+
+variable "provision_ssh_key" {
+  default     = "~/.ssh/id_rsa"
+  description = "File path to SSH private key used to access the provisioned nodes. Ensure this key is listed in the manager and work ssh keys list"
+}
+
+variable "provision_user" {
+  default     = "core"
+  description = "User used to log in to the droplets via ssh for issueing Docker commands"
+}
+
+variable "region" {
+  description = "Datacenter region in which the cluster will be created"
+  default     = "ams3"
+}
+
+variable "total_instances" {
+  description = "Total number of instances of this type in cluster"
+  default     = 1
+}
+
+variable "image" {
+  description = "Operating system for the worker nodes"
+  default     = "coreos-alpha"
+}
+
+variable "size" {
+  description = "Droplet size of worker nodes"
+  default     = "s-1vcpu-1gb"
+}
+
+variable "backups" {
+  default     = false
+  description = "Enable backups of the worker nodes"
+}
+
+variable "name" {
+  description = "Prefix for name of worker nodes"
+  default     = "worker"
+}
+
+variable "user_data" {
+  description = "User data content for worker nodes. Use this for installing a configuration management tool, such as Puppet or installing Docker"
+  default     = ""
+}
+
+variable "docker_cmd" {
+  description = "Docker command"
+  default     = "sudo docker"
+}
+
+variable "tags" {
+  description = "List of DigitalOcean tag ids"
+  default     = []
+  type        = "list"
+}
+
+variable "availability" {
+  description = "Availability of the node ('active'|'pause'|'drain')"
+  default     = "active"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "do_token" {
-  description = "DigitalOcean API token with read/write permissions"
-}
-
 variable "domain" {
   description = "Domain name used in droplet hostnames, e.g example.com"
 }
@@ -91,4 +87,19 @@ variable "worker_tags" {
   description = "List of DigitalOcean tag ids"
   default     = []
   type        = "list"
+}
+
+variable "remote_api_ca" {
+  description = "CA file path for the docker remote API"
+  default     = ""
+}
+
+variable "remote_api_key" {
+  description = "Private key file path for the docker remote API"
+  default     = ""
+}
+
+variable "remote_api_certificate" {
+  description = "Certificate file path for the docker remote API"
+  default     = ""
 }


### PR DESCRIPTION
- Support exposing the Docker Remote API using TLS when certificates are provided
- Add support for setting availability of the manager nodes on provisioning
- Add timeout to docker join and docker leave commands. Avoid long waiting time in case a host cannot be reached
- Add docker leave command when destroying a manager node, allows for down-scaling the amount of managers
- Fix some issues with docker join bash scripting
- Improve scripts to join worker nodes to cluster
- Remove need to pass do_token variable. Now instead uses the provider passed to the module
- Move manager and worker modules into a single repository, in the modules directory

