### PR TITLE
Connection timeout

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,9 +15,10 @@ module "managers" {
   remote_api_key         = "${var.remote_api_key}"
   remote_api_certificate = "${var.remote_api_certificate}"
 
-  ssh_keys          = "${var.worker_ssh_keys}"
-  provision_ssh_key = "${var.provision_ssh_key}"
-  provision_user    = "${var.provision_user}"
+  ssh_keys           = "${var.worker_ssh_keys}"
+  provision_ssh_key  = "${var.provision_ssh_key}"
+  provision_user     = "${var.provision_user}"
+  connection_timeout = "${var.connection_timeout}"
 }
 
 module "workers" {
@@ -36,7 +37,8 @@ module "workers" {
   manager_private_ip = "${element(module.managers.ipv4_addresses_private, 0)}"
   join_token         = "${module.managers.worker_token}"
 
-  ssh_keys          = "${var.worker_ssh_keys}"
-  provision_ssh_key = "${var.provision_ssh_key}"
-  provision_user    = "${var.provision_user}"
+  ssh_keys           = "${var.worker_ssh_keys}"
+  provision_ssh_key  = "${var.provision_ssh_key}"
+  provision_user     = "${var.provision_user}"
+  connection_timeout = "${var.connection_timeout}"
 }

--- a/modules/managers/main.tf
+++ b/modules/managers/main.tf
@@ -33,7 +33,7 @@ resource "digitalocean_droplet" "manager" {
     type        = "ssh"
     user        = "${var.provision_user}"
     private_key = "${file("${var.provision_ssh_key}")}"
-    timeout     = "2m"
+    timeout     = "${var.connection_timeout}"
   }
 
   provisioner "file" {

--- a/modules/managers/main.tf
+++ b/modules/managers/main.tf
@@ -73,7 +73,7 @@ resource "null_resource" "manager_api_access" {
     type        = "ssh"
     user        = "${var.provision_user}"
     private_key = "${file("${var.provision_ssh_key}")}"
-    timeout     = "2m"
+    timeout     = "${var.connection_timeout}"
   }
 
   provisioner "remote-exec" {
@@ -134,7 +134,7 @@ resource "null_resource" "bootstrap" {
     type        = "ssh"
     user        = "${var.provision_user}"
     private_key = "${file("${var.provision_ssh_key}")}"
-    timeout     = "2m"
+    timeout     = "${var.connection_timeout}"
   }
 
   provisioner "file" {

--- a/modules/managers/variables.tf
+++ b/modules/managers/variables.tf
@@ -1,6 +1,6 @@
 variable "connection_timeout" {
   description = "Timeout for connection to servers"
-  default = "5m"
+  default = "2m"
 }
 
 variable "domain" {

--- a/modules/managers/variables.tf
+++ b/modules/managers/variables.tf
@@ -1,3 +1,8 @@
+variable "connection_timeout" {
+  description = "Timeout for connection to servers"
+  default = "5m"
+}
+
 variable "domain" {
   description = "Domain name used in droplet hostnames, e.g example.com"
 }

--- a/modules/workers/main.tf
+++ b/modules/workers/main.tf
@@ -25,7 +25,7 @@ resource "digitalocean_droplet" "node" {
     type        = "ssh"
     user        = "${var.provision_user}"
     private_key = "${file("${var.provision_ssh_key}")}"
-    timeout     = "2m"
+    timeout     = "${var.connection_timeout}"
   }
 
   provisioner "file" {

--- a/modules/workers/variables.tf
+++ b/modules/workers/variables.tf
@@ -1,6 +1,6 @@
 variable "connection_timeout" {
-  description = "Timeout for conenction to servers"
-  default = "5m"
+  description = "Timeout for connection to servers"
+  default = "2m"
 }
 
 variable "domain" {

--- a/modules/workers/variables.tf
+++ b/modules/workers/variables.tf
@@ -1,3 +1,8 @@
+variable "connection_timeout" {
+  description = "Timeout for conenction to servers"
+  default = "5m"
+}
+
 variable "domain" {
   description = "Domain name used in droplet hostnames, e.g example.com"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "connection_timeout" {
   description = "Timeout for connection to servers"
-  default = "5m"
+  default = "2m"
 }
 
 variable "domain" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "connection_timeout" {
+  description = "Timeout for connection to servers"
+  default = "5m"
+}
+
 variable "domain" {
   description = "Domain name used in droplet hostnames, e.g example.com"
 }


### PR DESCRIPTION
I've added a  variable named `connection_timeout` with a default value of 2m.

Rationale: we are installing docker ce via the `user_data` var. This can take up to several minutes more than the 2m timeout that was hard-coded in the modules. Then terraform keeps spinning without end. 

By configuring the connection timeout via a variable, users can set it to whatever value works for them.