### PR TITLE
fix(managers): uncomment user_data variable

### DIFF
--- a/modules/managers/main.tf
+++ b/modules/managers/main.tf
@@ -25,10 +25,9 @@ resource "digitalocean_droplet" "manager" {
   backups            = "${var.backups}"
   ipv6               = false
   tags               = ["${var.tags}"]
-
-  # user_data          = "${var.user_data}"
-  count = "${var.total_instances}"
-  name  = "${format("%s-%02d.%s.%s", var.name, count.index + 1, var.region, var.domain)}"
+  user_data          = "${var.user_data}"
+  count              = "${var.total_instances}"
+  name               = "${format("%s-%02d.%s.%s", var.name, count.index + 1, var.region, var.domain)}"
 
   connection {
     type        = "ssh"


### PR DESCRIPTION
The `user_data` variable should still be supported for manager nodes. This commit reverts the accidental commenting of the `user_data` variable.