### PR TITLE
Ensure SSH keys is always referenced as a list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ module "managers" {
   remote_api_key         = "${var.remote_api_key}"
   remote_api_certificate = "${var.remote_api_certificate}"
 
-  ssh_keys           = "${var.worker_ssh_keys}"
+  ssh_keys           = ["${var.worker_ssh_keys}"]
   provision_ssh_key  = "${var.provision_ssh_key}"
   provision_user     = "${var.provision_user}"
   connection_timeout = "${var.connection_timeout}"
@@ -37,7 +37,7 @@ module "workers" {
   manager_private_ip = "${element(module.managers.ipv4_addresses_private, 0)}"
   join_token         = "${module.managers.worker_token}"
 
-  ssh_keys           = "${var.worker_ssh_keys}"
+  ssh_keys           = ["${var.worker_ssh_keys}"]
   provision_ssh_key  = "${var.provision_ssh_key}"
   provision_user     = "${var.provision_user}"
   connection_timeout = "${var.connection_timeout}"

--- a/modules/managers/main.tf
+++ b/modules/managers/main.tf
@@ -17,7 +17,7 @@ data "template_file" "provision_manager" {
 }
 
 resource "digitalocean_droplet" "manager" {
-  ssh_keys           = "${var.ssh_keys}"
+  ssh_keys           = ["${var.ssh_keys}"]
   image              = "${var.image}"
   region             = "${var.region}"
   size               = "${var.size}"

--- a/modules/workers/main.tf
+++ b/modules/workers/main.tf
@@ -9,7 +9,7 @@ data "template_file" "join_cluster_as_worker" {
 }
 
 resource "digitalocean_droplet" "node" {
-  ssh_keys           = "${var.ssh_keys}"
+  ssh_keys           = ["${var.ssh_keys}"]
   image              = "${var.image}"
   region             = "${var.region}"
   size               = "${var.size}"


### PR DESCRIPTION
Currently unable to build the project without this on the latest terraform (not 0.12)

```
Error: module.swarm-cluster.module.workers.digitalocean_droplet.node[1]: ssh_keys: should be a list
```